### PR TITLE
Fix assert! macro usage

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -14,8 +14,7 @@ mod tests {
     fn test_bench_time_it() {
         let (u, d) = time_it(|| 123);
         assert_eq!(u, 123);
-        assert!(d > Duration::new(0,0);
-        )
+        assert!(d > Duration::new(0,0));
     }
 
 }


### PR DESCRIPTION
There is a bug in rustc that allows adding invalid trailing tokens to the `assert!` macro call. They are currently ignored but are going to produce errors in the future.

Fix assert! macro usage to remove extra tokens.

For more information, see https://github.com/rust-lang/rust/issues/60024 and https://github.com/rust-lang/rust/pull/60039
